### PR TITLE
#63 - employer update about

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 .idea/
 
 docs/out/*
+
+media

--- a/core/models.py
+++ b/core/models.py
@@ -18,7 +18,7 @@ def upload_directory_path(instance, filename):
     Directory path function: Return unique path name for file uploading.
     Example:- YYYT-MM-DD/instance_name/file_name
     """
-    return '{0}/{1}/{2}'.format(date.today(), instance, filename)
+    return '{0}/{1}/{2}'.format(date.today(), (str(instance).split('.')[0]), filename)
 
 class BaseModel(UUIDModel):
     """

--- a/employers/serializers.py
+++ b/employers/serializers.py
@@ -1,0 +1,121 @@
+from rest_framework import serializers
+
+from project_meta.models import Media
+from user_profile.models import EmployerProfile
+from users.models import User
+
+
+class UpdateAboutSerializers(serializers.ModelSerializer):
+    """
+    UpdateAboutSerializers:
+        A Django REST framework serializer for updating information of an EmployerProfile model instance.
+
+    Fields:
+        - organization_name: A CharField that represents the name of the organization. It has an input type of "text"
+                             and is write-only. It cannot be blank.
+        - mobile_number: A CharField that represents the mobile number of the organization. It has an input type of
+                         "text" and is write-only. It cannot be blank and must contain only numbers.
+        - country_code: A CharField that represents the country code for the mobile number. It has an input type of
+                        "text" and is write-only. It cannot be blank.
+        - license: A FileField that represents the license of the organization. It has an input type of "file" and is
+                   write-only. It cannot be null.
+
+    Methods:
+        - validate_license_id: Validates the license_id field and raises a ValidationError if it is blank.
+        - validate_mobile_number: Validates the mobile_number field and raises a ValidationError if it is not a digit,
+          too long, already in use, or blank.
+        - validate: Validates the country_code, mobile_number, license_id, and license fields.
+        
+    Raises a ValidationError if any of the fields are blank when the corresponding field is present.
+        - update: Updates the EmployerProfile instance with the validated data. It updates the User model with the
+                  organization_name and mobile_number fields. The license field is saved in the Media model and the
+                  instance is linked to the license_id_file field in the EmployerProfile model.
+
+    Note:
+        The EmployerProfile model must have the fields specified in the 'fields' attribute of the Meta class.
+        The User model must have the fields 'name', 'mobile_number', and 'country_code'.
+    """
+    organization_name = serializers.CharField(
+        style={"input_type": "text"},
+        write_only=True,
+        allow_blank=False
+    )
+    mobile_number = serializers.CharField(
+        style={"input_type": "text"},
+        write_only=True,
+        allow_blank=False
+    )
+    country_code = serializers.CharField(
+        style={"input_type": "text"},
+        write_only=True,
+        allow_blank=False
+    )
+    license = serializers.FileField(
+        style={"input_type": "file"},
+        write_only=True,
+        allow_null=False
+    )
+
+    class Meta:
+        model = EmployerProfile
+        fields = ['organization_name', 'mobile_number',  'country_code', 'organization_type',
+                  'market_information_notification', 'other_notification', 'license_id', 'license']
+        
+    def validate_license_id(self, license_id):
+        if license_id == '':
+            raise serializers.ValidationError('License id can not be blank sfs', code='license_id')
+        else:
+            return license_id
+    
+    def validate_mobile_number(self, mobile_number):
+        if mobile_number != '':
+            if mobile_number.isdigit():
+                try:
+                    if len(mobile_number) > 13 :
+                        raise serializers.ValidationError('This is an invalid mobile number.', code='mobile_number')
+                    else:
+                        if User.objects.get(mobile_number=mobile_number):
+                            raise serializers.ValidationError('Mobile number already in use.', code='mobile_number')
+                except User.DoesNotExist:
+                    return mobile_number
+            else:
+                raise serializers.ValidationError('Mobile number must contain only numbers', code='mobile_number')
+        else:
+            raise serializers.ValidationError('Mobile number can not be blank', code='mobile_number')
+        
+    def validate(self, data):
+        country_code = data.get("country_code")
+        mobile_number = data.get("mobile_number")
+        license_id = data.get("license_id")
+        license = data.get("license")
+        if mobile_number and country_code in ["", None]:
+            raise serializers.ValidationError({'country_code': 'Country code can not be blank.'})
+        if license_id and license in ["", None]:
+            raise serializers.ValidationError({'license': 'License can not be blank.'})
+        if license and license_id in ["", None]:
+            raise serializers.ValidationError({'license_id': 'License id can not be blank. hkhkh'})
+        return data
+
+    def update(self, instance, validated_data):
+        super().update(instance, validated_data)
+        if 'organization_name' in validated_data:
+            instance.user.name = validated_data['organization_name']
+            instance.user.save()
+        if 'mobile_number' in validated_data:
+            instance.user.mobile_number = validated_data['mobile_number']
+            instance.user.country_code = validated_data['country_code']
+            instance.user.save()
+        if 'license' in validated_data:
+            # Get media type from upload license file
+            content_type = str(validated_data['license'].content_type).split("/")
+            if content_type[0] == "application":
+                media_type = 'document'
+            else:
+                media_type = content_type[0]
+            # save media file into media table and get instance of saved data.
+            media_instance = Media(file_path=validated_data['license'], media_type=media_type)
+            media_instance.save()
+            # save media instance into license id file into employer profile table.
+            instance.license_id_file = media_instance
+            instance.save()
+        return instance

--- a/employers/urls.py
+++ b/employers/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from .views import UpdateAboutView
+
+app_name = "employers"
+
+urlpatterns = [
+
+    path('', UpdateAboutView.as_view(), name="update_about"),
+    
+]

--- a/employers/views.py
+++ b/employers/views.py
@@ -1,3 +1,50 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404
 
-# Create your views here.
+from rest_framework import (
+    generics, response, status, permissions, serializers
+)
+
+from user_profile.models import EmployerProfile
+
+from .serializers import (
+    UpdateAboutSerializers
+)
+
+
+class UpdateAboutView(generics.GenericAPIView):
+    """
+    A class-based view for updating the 'about' information of an EmployerProfile.
+
+    This view is designed to handle PATCH requests and is only accessible by authenticated users. 
+    The view uses the `UpdateAboutSerializers` class as the serializer for handling the incoming data and 
+    performing validation. 
+
+    If the request data is valid, the view updates the `EmployerProfile` instance associated with the current user 
+    and returns a success message. If the request data is not valid, the view returns an error message.
+
+    Attributes:
+        - serializer_class (UpdateAboutSerializers): The serializer class for handling incoming data.
+        - permission_classes (list): The permission classes required for accessing this view, where only authenticated 
+                                      users are allowed.
+    """
+    
+    serializer_class = UpdateAboutSerializers
+    permission_classes = [permissions.IsAuthenticated]
+
+    def patch(self, request):
+        context = dict()
+        profile_instance = get_object_or_404(EmployerProfile, user=request.user)
+        serializer = self.serializer_class(data=request.data, instance=profile_instance, partial=True)
+        try:
+            serializer.is_valid(raise_exception=True)
+            if serializer.update(profile_instance, serializer.validated_data):
+                context['message'] = "Updated Successfully"
+                return response.Response(
+                    data=context,
+                    status=status.HTTP_200_OK
+                )
+        except serializers.ValidationError:
+            return response.Response(
+                data=serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/koor/urls/v1.py
+++ b/koor/urls/v1.py
@@ -4,4 +4,6 @@ app_name="v1"
 
 urlpatterns = [
     path('users', include('users.urls')),
+    
+    path('users/employer', include('employers.urls')),
 ]

--- a/project_meta/models.py
+++ b/project_meta/models.py
@@ -37,7 +37,7 @@ class Media(BaseModel, models.Model):
     )
 
     def __str__(self):
-        return self.file_path
+        return str(self.file_path)
 
     class Meta:
         verbose_name = "Media"


### PR DESCRIPTION
# Pull Request

## Description
- Modified directory path for upload any file in upload_directory_path function in models file of core directory.
- Create url path for update employer profile data in urls file of koor directory and employers directory.
- Covert return parameter in media class in models file of project_meta directory.
- Add media directory into gitignore file.

Here we create a UpdateAboutView in view file and UpdateAboutSerializers in serializers file.

### UpdateAboutSerializers
A Django REST framework serializer for updating information of an EmployerProfile model instance.

Fields:
- `organization_name`: A CharField that represents the name of the organization. It has an input type of "text" and is write-only. It cannot be blank.
- `mobile_number`: A CharField that represents the mobile number of the organization. It has an input type of "text" and is write-only. It cannot be blank and must contain only numbers.
- `country_code`: A CharField that represents the country code for the mobile number. It has an input type of "text" and is write-only. It cannot be blank.
- `license`: A FileField that represents the license of the organization. It has an input type of "file" and is write-only. It cannot be null.

Methods:
- `validate_license_id`: Validates the license_id field and raises a ValidationError if it is blank.
- `validate_mobile_number`: Validates the mobile_number field and raises a ValidationError if it is not a digit, too long, already in use, or blank.
- `validate`: Validates the country_code, mobile_number, license_id, and license fields.

        
Raises a ValidationError if any of the fields are blank when the corresponding field is present.
- `update`: Updates the EmployerProfile instance with the validated data. It updates the User model with the organization_name and mobile_number fields. The license field is saved in the Media model and the instance is linked to the license_id_file field in the EmployerProfile model.

Note:
- The EmployerProfile model must have the fields specified in the 'fields' attribute of the Meta class.
- The User model must have the fields 'name', 'mobile_number', and 'country_code'.

### UpdateAboutView
A class-based view for updating the 'about' information of an EmployerProfile.

This view is designed to handle `PATCH` requests and is only accessible by authenticated users. 
The view uses the `UpdateAboutSerializers` class as the serializer for handling the incoming data and performing validation. 

If the request data is valid, the view updates the `EmployerProfile` instance associated with the current user and returns a success message. If the request data is not valid, the view returns an error message.

Attributes:
- `serializer_class (UpdateAboutSerializers)`: The serializer class for handling incoming data.
- `permission_classes (list)`: The permission classes required for accessing this view, where only authenticated users are allowed.

## Change type

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

#### Document Update
Convert request body parameter from camel case to snake case.
- typeOfOrganization -> `organization_type`
- organizationName -> `organization_name`
- mobileNumber -> `mobile_number`
- countryCode -> `country_code`
- licenseId -> `license_id`

Add two new parameter for `boolean` value:-
- `market_information_notification`
- `other_notification`

Change response status from 204 to 200.

