### PR TITLE
#12 - create language

### DIFF
--- a/superadmin/serializers.py
+++ b/superadmin/serializers.py
@@ -4,7 +4,8 @@ from jobs.models import (
     JobCategory
 )
 from project_meta.models import (
-    Country, City, EducationLevel
+    Country, City, EducationLevel,
+    Language
 )
 
 
@@ -88,6 +89,7 @@ class JobCategorySerializers(serializers.ModelSerializer):
         model = JobCategory
         fields = ['id', 'title']
 
+
 class EducationLevelSerializers(serializers.ModelSerializer):
     """
     Serializer class for the `EducationLevel` model.
@@ -99,4 +101,18 @@ class EducationLevelSerializers(serializers.ModelSerializer):
 
     class Meta:
         model = EducationLevel
+        fields = ['id', 'title']
+
+
+class LanguageSerializers(serializers.ModelSerializer):
+    """
+    Serializer class for the ` Language` model.
+
+    The `LanguageSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the
+    `Language` model. It defines the fields that should be included in the serialized representation of the model,
+    including 'id', 'title'.
+    """
+
+    class Meta:
+        model = Language
         fields = ['id', 'title']

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (
     CountryView, CityView, JobCategoryView, 
-    EducationLevelView
+    EducationLevelView, LanguageView
     )
 
 app_name = "superadmin"
@@ -16,5 +16,7 @@ urlpatterns = [
     path('/job-category', JobCategoryView.as_view(), name="job_category"),
     
     path('/education-level', EducationLevelView.as_view(), name="education_level"),
+    
+    path('/language', LanguageView.as_view(), name="language"),
     
 ]

--- a/superadmin/views.py
+++ b/superadmin/views.py
@@ -351,13 +351,13 @@ class LanguageView(generics.ListAPIView):
 
     def post(self, request):
         """
-        Handle POST request to create a new education level.
-        The request must contain valid data for the education level to be created.
+        Handle POST request to create a new language.
+        The request must contain valid data for the language to be created.
 
-        Only users with `is_staff` attribute set to True are authorized to create a education level.
+        Only users with `is_staff` attribute set to True are authorized to create a language.
 
         Returns:
-            - HTTP 201 CREATED with a message "Language added successfully" if the education level is created
+            - HTTP 201 CREATED with a message "Language added successfully" if the language is created
             successfully.
             - HTTP 400 BAD REQUEST with error message if data validation fails.
             - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is

--- a/superadmin/views.py
+++ b/superadmin/views.py
@@ -1,21 +1,21 @@
 from rest_framework import (
     status, generics, serializers,
     response, permissions, filters
-    )
+)
 
 from core.pagination import CustomPagination
 
 from jobs.models import (
     JobCategory
-    )
+)
 from project_meta.models import (
-    Country, City, EducationLevel
-    )
+    Country, City, EducationLevel, Language
+)
 
 from .serializers import (
     CountrySerializers, CitySerializers, JobCategorySerializers,
-    EducationLevelSerializers
-    )
+    EducationLevelSerializers, LanguageSerializers
+)
 
 
 class CountryView(generics.ListAPIView):
@@ -242,7 +242,8 @@ class JobCategoryView(generics.ListAPIView):
                 data=context,
                 status=status.HTTP_400_BAD_REQUEST
             )
-            
+
+
 class EducationLevelView(generics.ListAPIView):
     """
     A view for displaying a list of education levels .
@@ -281,6 +282,82 @@ class EducationLevelView(generics.ListAPIView):
 
         Returns:
             - HTTP 201 CREATED with a message "EducationLevel added successfully" if the education level is created
+            successfully.
+            - HTTP 400 BAD REQUEST with error message if data validation fails.
+            - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is
+            not authorized.
+
+        Raises:
+            Exception: If an unexpected error occurs during the request handling.
+        """
+        context = dict()
+        serializer = self.serializer_class(data=request.data)
+        try:
+            if self.request.user.is_staff:
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
+                context["data"] = serializer.data
+                return response.Response(
+                    data=context,
+                    status=status.HTTP_201_CREATED
+                )
+            else:
+                context['message'] = "You do not have permission to perform this action."
+                return response.Response(
+                    data=context,
+                    status=status.HTTP_401_UNAUTHORIZED
+                )
+        except serializers.ValidationError:
+            return response.Response(
+                data=serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        except Exception as e:
+            context['message'] = str(e)
+            return response.Response(
+                data=context,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+
+class LanguageView(generics.ListAPIView):
+    """
+    A view for displaying a list of education levels .
+
+    Attributes:
+        - permission_classes ([permissions.IsAuthenticated]): List of permission classes that the view requires. In this
+            case, only authenticated users are allowed to access the view.
+
+        - serializer_class (LanguageSerializers): The serializer class used for data validation and serialization.
+
+        - queryset (QuerySet): The queryset that the view should use to retrieve the countries. By default, it is set
+            to retrieve all countries using `Language.objects.all()`.
+
+        - filter_backends ([filters.SearchFilter]): List of filter backends to use for filtering the queryset. In this
+            case, only `SearchFilter` is used.
+
+        - search_fields (list): List of fields to search for in the queryset. In this case, the field is "title".
+
+        - pagination_class (CustomPagination): The pagination class to use for paginating the queryset results.
+
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = LanguageSerializers
+    queryset = Language.objects.all()
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['title']
+    pagination_class = CustomPagination
+
+    def post(self, request):
+        """
+        Handle POST request to create a new education level.
+        The request must contain valid data for the education level to be created.
+
+        Only users with `is_staff` attribute set to True are authorized to create a education level.
+
+        Returns:
+            - HTTP 201 CREATED with a message "Language added successfully" if the education level is created
             successfully.
             - HTTP 400 BAD REQUEST with error message if data validation fails.
             - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is


### PR DESCRIPTION
# Pull Request

## Description
Here we create `LanguageSerializers` and `LanguageView`.

- Create url path for create and get education level api

### LanguageSerializers
Serializer class for the `Language` model.

The `LanguageSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the `Language` model. It defines the fields that should be included in the serialized representation of the model, including 'id', 'title'.

### LanguageView
A view for displaying a list of language levels .

##### Attributes:
- `permission_classes ([permissions.IsAuthenticated])`: List of permission classes that the view requires. In this case, only authenticated users are allowed to access the view.

- `serializer_class (LanguageSerializers)`: The serializer class used for data validation and serialization.

- `queryset (QuerySet)`: The queryset that the view should use to retrieve the countries. By default, it is set to retrieve all countries using `Language.objects.all()`.

- `filter_backends ([filters.SearchFilter])`: List of filter backends to use for filtering the queryset. In this case, only `SearchFilter` is used.

- `search_fields (list)`: List of fields to search for in the queryset. In this case, the field is "title".

- `pagination_class (CustomPagination)`: The pagination class to use for paginating the queryset results.

###### POST function:
- Handle `POST` request to create a new language.

- The request must contain valid data for the language to be created.

- Only users with `is_staff` attribute set to True are authorized to create a language.

##### Returns:
- HTTP `201 CREATED` with a message `"Language added successfully"` if the language is created successfully.
- HTTP `400 BAD REQUEST` with error message if data validation fails.
- HTTP `401 UNAUTHORIZED` with a message "You do not have permission to perform this action." if the user is not authorized.

##### Raises:
- `Exception`: If an unexpected error occurs during the request handling.


## Change type

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

#### Document Update

##### for get language issue:

Modify response parameter form `languages` to `results`