### PR TITLE
#15 - create skills

### DIFF
--- a/superadmin/serializers.py
+++ b/superadmin/serializers.py
@@ -5,7 +5,7 @@ from jobs.models import (
 )
 from project_meta.models import (
     Country, City, EducationLevel,
-    Language
+    Language, Skill
 )
 
 
@@ -115,4 +115,18 @@ class LanguageSerializers(serializers.ModelSerializer):
 
     class Meta:
         model = Language
+        fields = ['id', 'title']
+
+
+class SkillSerializers(serializers.ModelSerializer):
+    """
+    Serializer class for the ` Skill` model.
+
+    The `SkillSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the
+    `Skill` model. It defines the fields that should be included in the serialized representation of the model,
+    including 'id', 'title'.
+    """
+
+    class Meta:
+        model = Skill
         fields = ['id', 'title']

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (
     CountryView, CityView, JobCategoryView, 
-    EducationLevelView, LanguageView
+    EducationLevelView, LanguageView, SkillView
     )
 
 app_name = "superadmin"
@@ -18,5 +18,7 @@ urlpatterns = [
     path('/education-level', EducationLevelView.as_view(), name="education_level"),
     
     path('/language', LanguageView.as_view(), name="language"),
+    
+    path('/skills', SkillView.as_view(), name="skills"),
     
 ]

--- a/superadmin/views.py
+++ b/superadmin/views.py
@@ -9,12 +9,13 @@ from jobs.models import (
     JobCategory
 )
 from project_meta.models import (
-    Country, City, EducationLevel, Language
+    Country, City, EducationLevel, 
+    Language, Skill
 )
 
 from .serializers import (
     CountrySerializers, CitySerializers, JobCategorySerializers,
-    EducationLevelSerializers, LanguageSerializers
+    EducationLevelSerializers, LanguageSerializers, SkillSerializers
 )
 
 
@@ -281,8 +282,7 @@ class EducationLevelView(generics.ListAPIView):
         Only users with `is_staff` attribute set to True are authorized to create a education level.
 
         Returns:
-            - HTTP 201 CREATED with a message "EducationLevel added successfully" if the education level is created
-            successfully.
+            - HTTP 201 CREATED with added education level data (id, title) if the education level is created successfully.
             - HTTP 400 BAD REQUEST with error message if data validation fails.
             - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is
             not authorized.
@@ -357,8 +357,82 @@ class LanguageView(generics.ListAPIView):
         Only users with `is_staff` attribute set to True are authorized to create a language.
 
         Returns:
-            - HTTP 201 CREATED with a message "Language added successfully" if the language is created
-            successfully.
+            - HTTP 201 CREATED with added language data (id, title) if the language is created successfully.
+            - HTTP 400 BAD REQUEST with error message if data validation fails.
+            - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is
+            not authorized.
+
+        Raises:
+            Exception: If an unexpected error occurs during the request handling.
+        """
+        context = dict()
+        serializer = self.serializer_class(data=request.data)
+        try:
+            if self.request.user.is_staff:
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
+                context["data"] = serializer.data
+                return response.Response(
+                    data=context,
+                    status=status.HTTP_201_CREATED
+                )
+            else:
+                context['message'] = "You do not have permission to perform this action."
+                return response.Response(
+                    data=context,
+                    status=status.HTTP_401_UNAUTHORIZED
+                )
+        except serializers.ValidationError:
+            return response.Response(
+                data=serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        except Exception as e:
+            context['message'] = str(e)
+            return response.Response(
+                data=context,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+
+class SkillView(generics.ListAPIView):
+    """
+    A view for displaying a list of skills .
+
+    Attributes:
+        - permission_classes ([permissions.IsAuthenticated]): List of permission classes that the view requires. In this
+            case, only authenticated users are allowed to access the view.
+
+        - serializer_class (SkillSerializers): The serializer class used for data validation and serialization.
+
+        - queryset (QuerySet): The queryset that the view should use to retrieve the countries. By default, it is set
+            to retrieve all countries using `Skill.objects.all()`.
+
+        - filter_backends ([filters.SearchFilter]): List of filter backends to use for filtering the queryset. In this
+            case, only `SearchFilter` is used.
+
+        - search_fields (list): List of fields to search for in the queryset. In this case, the field is "title".
+
+        - pagination_class (CustomPagination): The pagination class to use for paginating the queryset results.
+
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = SkillSerializers
+    queryset = Skill.objects.all()
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['title']
+    pagination_class = CustomPagination
+
+    def post(self, request):
+        """
+        Handle POST request to create a new skill.
+        The request must contain valid data for the skill to be created.
+
+        Only users with `is_staff` attribute set to True are authorized to create a skill.
+
+        Returns:
+            - HTTP 201 CREATED with added skill data (id, title) if the skill is created successfully.
             - HTTP 400 BAD REQUEST with error message if data validation fails.
             - HTTP 401 UNAUTHORIZED with a message "You do not have permission to perform this action." if the user is
             not authorized.


### PR DESCRIPTION
# Pull Request

## Description
Here we create `SkillSerializers` and `SkillView`.

- Create url path for create and get skill api

### SkillSerializers
Serializer class for the ` Skill` model.

The `SkillSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the `Skill` model. It defines the fields that should be included in the serialized representation of the model, including 'id', 'title'.

### SkillView
A view for displaying a list of skills.

#### Attributes:
- `permission_classes ([permissions.IsAuthenticated])`: List of permission classes that the view requires. In this case, only authenticated users are allowed to access the view.

- `serializer_class (SkillSerializers)`: The serializer class used for data validation and serialization.

- `queryset (QuerySet)`: The query set that the view should use to retrieve the countries. It is default set to retrieve all countries using `Skill.objects.all()`.

- `filter_backends ([filters.SearchFilter])`: List of filter backends to use for filtering the query set. In this case, only `SearchFilter` is used.

- `search_fields (list)`: List of fields to search for in the query set. In this case, the field is `"title"`.

- `pagination_class (CustomPagination)`: The pagination class to use for paginating the query set results.

##### POST function:
- Handle `POST` requests to create a new skill.
- The request must contain valid data for the skill to be created.

Only users with `is_staff` attribute set to True are authorized to create a skill.

##### Returns:
- HTTP `201 CREATED` with added skill data (id, title) if the skill is created successfully.
- HTTP `400 BAD REQUEST` with an error message if data validation fails.
- HTTP `401 UNAUTHORIZED` with a message `"You do not have permission to perform this action."` if the user is not authorized.

##### Raises:
- `Exception`: If an unexpected error occurs during the request handling.


## Change type

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

#### Document Update

##### for getting language issues:

Modify the response parameter from `skills` to `results`
