### PR TITLE
#166 - get user rights

### DIFF
--- a/superadmin/serializers.py
+++ b/superadmin/serializers.py
@@ -10,6 +10,8 @@ from project_meta.models import (
 
 from users.backends import MobileOrEmailBackend as cb
 
+from .models import Content
+
 
 class CountrySerializers(serializers.ModelSerializer):
     """
@@ -172,7 +174,7 @@ class ChangePasswordSerializers(serializers.Serializer):
         the request data is invalid or if the authentication fails.
 
     """
-    
+
     old_password = serializers.CharField(
         style={"input_type": "text"},
         write_only=True
@@ -204,3 +206,17 @@ class ChangePasswordSerializers(serializers.Serializer):
                 raise serializers.ValidationError({'message': 'Invalid login credentials.'})
         except:
             raise serializers.ValidationError({'message': 'Invalid login credentials.'})
+
+
+class ContentSerializers(serializers.ModelSerializer):
+    """
+    Serializer class for the `Content` model.
+
+    The `ContentSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the
+    `Content` model. It defines the fields that should be included in the serialized representation of the model,
+    including 'description'.
+    """
+
+    class Meta:
+        model = Content
+        fields = ['description']

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import (
     CountryView, CityView, JobCategoryView, 
     EducationLevelView, LanguageView, SkillView,
-    TagView, ChangePasswordView
+    TagView, ChangePasswordView, UserRightsView
     )
 
 app_name = "superadmin"
@@ -30,4 +30,6 @@ urlpatterns = [
     path('/tag/<str:tagId>', TagView.as_view(), name="tag"),
     
     path('/change-password', ChangePasswordView.as_view(), name="change_password"),
+    
+    path('/user-rights', UserRightsView.as_view(), name="user_rights"),
 ]

--- a/superadmin/views.py
+++ b/superadmin/views.py
@@ -16,10 +16,12 @@ from project_meta.models import (
     Country, City, EducationLevel,
     Language, Skill, Tag
 )
+
+from .models import Content
 from .serializers import (
     CountrySerializers, CitySerializers, JobCategorySerializers,
     EducationLevelSerializers, LanguageSerializers, SkillSerializers,
-    TagSerializers, ChangePasswordSerializers
+    TagSerializers, ChangePasswordSerializers, ContentSerializers
 )
 
 
@@ -832,6 +834,67 @@ class ChangePasswordView(generics.GenericAPIView):
             return response.Response(
                 data=serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST
+            )
+        except Exception as e:
+            response_context['message'] = str(e)
+            return response.Response(
+                data=response_context,
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+
+class UserRightsView(generics.GenericAPIView):
+    """
+    View to retrieve the user rights.
+
+    This view extends the GenericAPIView class from Django Rest Framework and defines the permission_classes and
+    serializer_class attributes to control the access permissions and serialization of data.
+
+    Attributes:
+        - `permission_classes (list)`: A list of permission classes that allow any user to access the view.
+        - `serializer_class (ContentSerializers)`: The serializer class used to serialize the data retrieved from
+        the view.
+
+    """
+
+    permission_classes = [permissions.AllowAny]
+    serializer_class = ContentSerializers
+
+    def get(self, request):
+        """
+        Retrieve the user rights content.
+
+        This method retrieves the user rights content from the database using the Content model, serializes it using the
+        serializer_class attribute, and returns it as a response.
+
+        Args:
+            - `request (HttpRequest)`: The HTTP request sent to the view.
+
+        Returns:
+            - A Response object with the user rights content as data and a 200 status code if the content is found in
+            the database.
+            - A Response object with a description field as data and a 404 status code if the content is not found in
+            the database.
+            - A Response object with an error message as data and a 400 status code if an exception occurs.
+
+        Raises:
+            None.
+
+        """
+
+        response_context = dict()
+        try:
+            content_instance = Content.objects.get(title="User Rights")
+            get_data = self.serializer_class(content_instance)
+            response_context = get_data.data
+            return response.Response(
+                data=response_context,
+                status=status.HTTP_200_OK
+            )
+        except Content.DoesNotExist:
+            return response.Response(
+                data={"description": None},
+                status=status.HTTP_404_NOT_FOUND
             )
         except Exception as e:
             response_context['message'] = str(e)


### PR DESCRIPTION
# Pull Request

## Description
Created `ContentSerializers` and `UserRightsView` to getting user rights API.
Create a URL path to get user rights API.

### ContentSerializers
Serializer class for the `Content` model.

The `ContentSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the `Content` model. It defines the fields that should be included in the serialized representation of the model, including 'description'.

### UserRightsView
View to retrieve the user rights.

This view extends the GenericAPIView class from Django Rest Framework and defines the `permission_classes` and `serializer_class` attributes to control the access permissions and serialization of data.

#### Attributes:
- `permission_classes (list)`: A list of permission classes that allow any user to access the view.
- `serializer_class (ContentSerializers)`: The serializer class used to serialize the data retrieved from the view.

##### Get Function:
Retrieve the user rights content.

This method retrieves the user rights content from the database using the Content model, serializes it using the serializer_class attribute, and returns it as a response.

#### Args:
- `request (HttpRequest)`: The HTTP request sent to the view.

#### Returns:
- A Response object with the user rights content as data and a 200 status code if the content is found in the database.
- A Response object with a description field as data and a 404 status code if the content is not found in the database.
- A Response object with an error message as data and a 400 status code if an exception occurs.

#### Raises:
- None.


## Change type

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
