### PR TITLE
#164 - get employers list

### DIFF
--- a/docs/admin/admin.md
+++ b/docs/admin/admin.md
@@ -690,6 +690,7 @@ This api is used to get all `Credit`
       "preiod": 0 || 1 || 2...  // 0 for current month ; 1 for last months
     },
   }
+  ```
 
 - response:
   ```js
@@ -719,6 +720,7 @@ This api is used to get all `Dashboard `
       "preiod": 0 || 1 || 2...  // 0 for current year ; 1 for last year
     },
   }
+  ```
 
 - response:
   ```js
@@ -747,6 +749,7 @@ This api is used to get all `Jobs List `
       "filter": "location" || ""  // for filtering data according to location
     },
   }
+  ```
 
 - response:
   ```js
@@ -777,6 +780,7 @@ This api is used to get all `Ttenders List `
       "filter": "location" || ""  // for filtering data according to location
     },
   }
+  ```
 
 - response:
   ```js
@@ -807,6 +811,7 @@ This api is used to get all `Employers List `
       "filter": "location" || ""  // for filtering data according to location
     },
   }
+  ```
 
 - response:
   ```js
@@ -839,6 +844,7 @@ This api is used to get all `Candidates List `
       "filter": "location" || ""  // for filtering data according to location
     },
   }
+  ```
 
 - response:
   ```js

--- a/superadmin/serializers.py
+++ b/superadmin/serializers.py
@@ -9,6 +9,7 @@ from project_meta.models import (
 )
 
 from users.backends import MobileOrEmailBackend as cb
+from users.models import User
 
 from .models import Content
 
@@ -220,7 +221,21 @@ class ContentSerializers(serializers.ModelSerializer):
     class Meta:
         model = Content
         fields = ['description']
-        
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
+
+
+class CandidatesSerializers(serializers.ModelSerializer):
+    """
+    Serializer class for the `User` model.
+
+    The `CandidatesSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the
+    `User` model. It defines the fields that should be included in the serialized representation of the model,
+    including 'id', 'role', 'name', 'email', 'country_code', 'mobile_number', 'is_active'.
+    """
+
+    class Meta:
+        model = User
+        fields = ['id', 'role', 'name', 'email', 'country_code', 'mobile_number', 'is_active']

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -4,7 +4,7 @@ from .views import (
     CountryView, CityView, JobCategoryView, 
     EducationLevelView, LanguageView, SkillView,
     TagView, ChangePasswordView, UserRightsView,
-    PrivacyPolicyView
+    PrivacyPolicyView, CandidatesListView
     )
 
 app_name = "superadmin"
@@ -35,4 +35,6 @@ urlpatterns = [
     path('/user-rights', UserRightsView.as_view(), name="user_rights"),
     
     path('/privacy-policy', PrivacyPolicyView.as_view(), name="privacy_policy"),
+    
+    path('/candidates-list', CandidatesListView.as_view(), name="candidates_list"),
 ]

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -4,7 +4,7 @@ from .views import (
     CountryView, CityView, JobCategoryView, 
     EducationLevelView, LanguageView, SkillView,
     TagView, ChangePasswordView, UserRightsView,
-    PrivacyPolicyView, CandidatesListView
+    PrivacyPolicyView, CandidatesListView, EmployerListView
     )
 
 app_name = "superadmin"
@@ -37,4 +37,6 @@ urlpatterns = [
     path('/privacy-policy', PrivacyPolicyView.as_view(), name="privacy_policy"),
     
     path('/candidates-list', CandidatesListView.as_view(), name="candidates_list"),
+    
+    path('/employer-list', EmployerListView.as_view(), name="employer_list"),
 ]


### PR DESCRIPTION
# Pull Request

## Description
Created `EmployerListView` to getting employer list API.
Create a URL path to get employer list API.

### EmployerListView
API view for listing employers by name.

This view requires the user to be authenticated, and `only allows staff` users to perform the listing. `Non-staff` users receive a `401 Unauthorized` response.

#### Attributes:
- `permission_classes (list)`: A list of permission classes required to access this view. In this case, it contains a single `IsAuthenticated` class.
- `serializer_class`: The serializer class used to convert model instances to JSON. In this case, it is `CandidatesSerializers`.
- `queryset`: The queryset used to fetch the data from the database. In this case, it is `User.objects.all()`, which returns all users in the database.
- `filter_backends`: A list of filter backends used to filter the queryset. In this case, it contains a single SearchFilter backend.
- `search_fields`: A list of model fields that can be used for text search. In this case, it contains the `'name'` field.

#### Methods:
- `list(request)`: The main method of this view, which returns a list of employers filtered by name.

#### Returns:
- A Response object with a list of employers, or an error message if the user is not authorized.


## Change type

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
