### PR TITLE
#231 - get notification

### DIFF
--- a/notification/serializers.py
+++ b/notification/serializers.py
@@ -1,0 +1,51 @@
+from rest_framework import serializers
+
+from job_seekers.serializers import GetAppliedJobsSerializers
+from notification.models import Notification
+
+
+class GetNotificationSerializers(serializers.ModelSerializer):
+
+    """
+    A serializer class for Notification objects, with a custom field for the application data.
+
+    The `application` field is a SerializerMethodField that returns the data of the related Application object,
+    serialized using the `GetAppliedJobsSerializers` class.
+
+    Attributes:
+        application: A SerializerMethodField that returns the data of the related Application object.
+
+    Meta:
+        model: The Notification model class to be serialized.
+        fields: A list of field names to be included in the serialized representation.
+
+    Methods:
+        get_application(obj): Returns the serialized data of the related Application object.
+
+    """
+
+    application = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = Notification
+        fields = [
+            'id', 'notification_type', 'application', 'job_filter', 'seen'
+        ]
+
+    def get_application(self, obj):
+        """
+        Returns the serialized data of the related Application object.
+
+        Args:
+            obj: The Notification object being serialized.
+
+        Returns:
+            A dictionary containing the serialized data of the related Application object,
+            or an empty dictionary if the related object does not exist or could not be serialized.
+
+        """
+        return_context = {}
+        get_data = GetAppliedJobsSerializers(obj.application, context={"request": self.context['request']})
+        if get_data.data:
+            return_context = get_data.data
+        return return_context

--- a/notification/views.py
+++ b/notification/views.py
@@ -1,3 +1,75 @@
-from django.shortcuts import render
+from rest_framework import (
+    generics, response, permissions, filters
+)
+from rest_framework.pagination import LimitOffsetPagination
 
-# Create your views here.
+from notification.models import Notification
+from notification.serializers import GetNotificationSerializers
+
+
+class NotificationView(generics.ListAPIView):
+    """
+    A view that returns a list of notifications for the authenticated user, filtered by type. Supports pagination with
+    limit-offset style.
+
+    Required Attributes:
+        - serializer_class: A Django REST Framework serializer class to use for converting notification objects into
+            JSON responses.
+        - permission_classes: A list of permission classes that define the access control policy for this view.
+        - filter_backends: A list of Django REST Framework filter backend classes that perform filtering on the
+            queryset.
+        - search_fields: A list of model fields that can be searched using the search filter backend.
+
+    Methods:
+        - list: A method that returns a JSON response containing a paginated list of notifications for the
+            authenticated user, filtered by type.
+
+    Attributes:
+        - queryset: The queryset to use for fetching notifications. This attribute is set to None to delay the query
+            until the `list` method is called.
+    """
+
+    serializer_class = GetNotificationSerializers
+    permission_classes = [permissions.IsAuthenticated]
+    queryset = None
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['type']
+
+    def list(self, request):
+        """
+        Return a JSON response containing a paginated list of notifications for the authenticated user, filtered by
+        type.
+
+        If a 'limit' query parameter is provided, pagination is performed using a limit-offset style. Otherwise, all
+        notifications for the user are returned.
+
+        Arguments:
+            - `request`: The incoming HTTP request.
+
+        Returns:
+            - A Django REST Framework Response object containing a JSON payload with the following keys:
+            - 'count': The total number of notifications in the response.
+            - 'next': A URL for the next page of results, or None if there is no next page.
+            - 'previous': A URL for the previous page of results, or None if there is no previous page.
+            - 'results': A list of notification objects, serialized as JSON.
+        """
+
+        queryset = Notification.objects.filter(user=self.request.user)
+        count = queryset.count()
+        next = None
+        previous = None
+        paginator = LimitOffsetPagination()
+        limit = self.request.query_params.get('limit')
+        if limit:
+            queryset = paginator.paginate_queryset(queryset, request)
+            count = paginator.count
+            next = paginator.get_next_link()
+            previous = paginator.get_previous_link()
+        serializer = self.serializer_class(queryset, many=True, context={"request": request})
+        return response.Response(
+            {'count': count,
+             "next": next,
+             "previous": previous,
+             "results": serializer.data
+             }
+        )

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from notification.views import NotificationView
 from .views import (
     UserView, CreateSessionView, DeleteSessionView,
     DisplayImageView, SendOtpView, ChangePasswordView,
@@ -28,6 +29,8 @@ urlpatterns = [
     path('/change-password', ChangePasswordView.as_view(), name="change_password"),
     
     path('/get-location', GetLocationView.as_view(), name="get_location"),
+    
+    path('/notification', NotificationView.as_view(), name="get_notification"),
     
     path('/email-verification/<str:otp>', VerificationView.as_view(), name="verification"),
 ]


### PR DESCRIPTION
# Pull Request

## Description

- create `GetNotificationSerializers` and `NotificationView` classes to get notifications using API.
- create URL for `get notification API.

### GetNotificationSerializers:
A serializer class for Notification objects, with a custom field for the application data.

The `application` field is a SerializerMethodField that returns the data of the related Application object, serialized using the `GetAppliedJobsSerializers` class.

#### Attributes:
- `application`: A `SerializerMethodField` that returns the data of the related Application object.

#### Meta:
- `model`: The `Notification` model class to be serialized.
- `fields`: A list of field names to be included in the serialized representation.

#### Methods:
- `get_application(obj)`: Returns the serialized data of the `related Application` object.

##### get_application:
Returns the serialized data of the related Application object.

#### Args:
- `obj`: The Notification object being serialized.

#### Returns:
A dictionary containing the serialized data of the related Application object, or an empty dictionary if the related object does not exist or could not be serialized.

### NotificationView:
A view that returns a list of notifications for the authenticated user, filtered by type. Supports pagination with limit-offset style.

#### Required Attributes:
- serializer_class: A Django REST Framework serializer class to use for converting notification objects into JSON responses.
- permission_classes: A list of permission classes that define the access control policy for this view.
- filter_backends: A list of Django REST Framework filter backend classes that perform filtering on the query set.
- search_fields: A list of model fields that can be searched using the search filter backend.

#### Methods:
- list: A method that returns a JSON response containing a paginated list of notifications for the authenticated user, filtered by type.

#### Attributes:
- queryset: The query set to use for fetching notifications. This attribute is set to None to delay the query until the `list` method is called.


##### List Function:
- Return a JSON response containing a paginated list of notifications for the authenticated user, filtered by type.

- If a 'limit' query parameter is provided, pagination is performed using a limit-offset style. Otherwise, all notifications for the user are returned.

#### Arguments:
- `request`: The incoming HTTP request.

#### Returns:
A Django REST Framework Response object containing a JSON payload with the following keys:
- 'count': The total number of notifications in the response.
- 'next': A URL for the next page of results, or None if there is no next page.
- 'previous': A URL for the previous page of results, or None if there is no previous page.
- 'results': A list of notification objects, serialized as JSON.

            

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
