### PR TITLE
#247 - search user

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -5,7 +5,7 @@ from .views import (
     UserView, CreateSessionView, DeleteSessionView,
     DisplayImageView, SendOtpView, ChangePasswordView,
     GetLocationView, SocialLoginView, OtpVerificationView,
-    VerificationView
+    VerificationView, SearchView
     )
 
 app_name = "users"
@@ -33,4 +33,6 @@ urlpatterns = [
     path('/notification', NotificationView.as_view(), name="get_notification"),
     
     path('/email-verification/<str:otp>', VerificationView.as_view(), name="verification"),
+    
+    path('/search/<str:role>', SearchView.as_view(), name="search"),
 ]


### PR DESCRIPTION
# Pull Request

## Description

- create `SearchView` for user search API.
- create a URL for search user API.

### SearchView:
A view that returns a list of candidates filtered by role and optionally searched by title.
The `role` parameter is required in the URL path.
The `limit` query parameter can be used to paginate the results.

- `Serializer class`: CandidatesSerializers
- `Permission classes`: AllowAny
- `Queryset`: all User objects
- `Filter backends`: SearchFilter
- `Search fields`: 'title'

#### HTTP methods:
- `GET`: returns a paginated list of candidates filtered by role and optionally searched by title.

#### Sample URLs:
- /candidates/developers/?limit=10&search=python
- /candidates/managers/?search=project+management

##### List Function:
Returns a paginated list of candidates filtered by role and optionally searched by title.

#### Parameters:
- `role`: str, the role of the candidates to retrieve (e.g., 'developers', 'managers')

#### Query parameters:
- `limit`: int, the maximum number of results to return per page (default: 100)
- `search`: str, the keyword(s) to search in the 'title' field of the candidates

#### Returns:
A JSON response with the following keys:
- `count`: int, the total number of candidates matching the filter/search criteria
- `next`: str or None, a URL to the next page of results (if any)
- `previous`: str or None, a URL to the previous page of results (if any)
- `results`: list of dicts, the serialized representations of the candidates matching the filter/search criteria

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
