### PR TITLE
#286 - active-inactive jobs for employer

### DIFF
--- a/employers/urls.py
+++ b/employers/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from .views import UpdateAboutView, JobsView, TendersView
+from .views import (
+    UpdateAboutView, JobsView,
+    TendersView, JobsStatusView
+)
 
 app_name = "employers"
 
@@ -10,6 +13,7 @@ urlpatterns = [
     
     path('/jobs', JobsView.as_view(), name="jobs"), 
     path('/jobs/<str:jobId>', JobsView.as_view(), name="jobs"),
+    path('/jobs/<str:jobId>/status', JobsStatusView.as_view(), name="jobs_status"),
     
     path('/tenders', TendersView.as_view(), name="tenders"),
     path('/tenders/<str:tendersId>', TendersView.as_view(), name="tenders"),

--- a/employers/urls.py
+++ b/employers/urls.py
@@ -9,9 +9,9 @@ urlpatterns = [
     path('/about-me', UpdateAboutView.as_view(), name="update_about"),
     
     path('/jobs', JobsView.as_view(), name="jobs"), 
-    
     path('/jobs/<str:jobId>', JobsView.as_view(), name="jobs"),
     
     path('/tenders', TendersView.as_view(), name="tenders"),
+    path('/tenders/<str:tendersId>', TendersView.as_view(), name="tenders"),
     
 ]


### PR DESCRIPTION
# Pull Request

## Description

- create a URL path for modifying jobs status API for the employer.
- create `JobsStatusView` for modifying the jobs status API for the employer.

### JobsStatusView:
View function for `updating the status` of a job instance.

#### Args:
- `request`: Request object containing metadata about the current request.
- `jobId`: Integer representing the ID of the job instance to be updated.

#### Returns:
Response object containing data about the updated job instance, along with an HTTP status code.

#### Raises:
- `Http404`: If the job instance with the given `jobId does not exist`.

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
