### PR TITLE
#307 - get saved tenders

### DIFF
--- a/job_seekers/serializers.py
+++ b/job_seekers/serializers.py
@@ -498,7 +498,7 @@ class GetSavedJobsSerializers(serializers.ModelSerializer):
     job = serializers.SerializerMethodField()
 
     class Meta:
-        model = AppliedJob
+        model = SavedJob
         fields = ['id', 'job']
 
     def get_job(self, obj):

--- a/job_seekers/views.py
+++ b/job_seekers/views.py
@@ -877,12 +877,24 @@ class JobsApplyView(generics.ListAPIView):
                 order_by = 'job__deadline'
             if 'order_by' in self.request.GET:
                 if 'descending' in self.request.GET['order_by']:
-                    return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by("-" + str(order_by))
+                    return AppliedJob.objects.filter(
+                        user=self.request.user,
+                        job__is_removed=False
+                    ).order_by("-" + str(order_by))
                 else:
-                    return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
+                    return AppliedJob.objects.filter(
+                        user=self.request.user,
+                        job__is_removed=False
+                    ).order_by(str(order_by))
             else:
-                return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
-        return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False)
+                return AppliedJob.objects.filter(
+                    user=self.request.user,
+                    job__is_removed=False
+                ).order_by(str(order_by))
+        return AppliedJob.objects.filter(
+            user=self.request.user,
+            job__is_removed=False
+        )
 
 
 class JobsSaveView(generics.ListAPIView):
@@ -1071,12 +1083,24 @@ class JobsSaveView(generics.ListAPIView):
                 order_by = 'job__deadline'
             if 'order_by' in self.request.GET:
                 if 'descending' in self.request.GET['order_by']:
-                    return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by("-" + str(order_by))
+                    return SavedJob.objects.filter(
+                        user=self.request.user,
+                        job__is_removed=False
+                    ).order_by("-" + str(order_by))
                 else:
-                    return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
+                    return SavedJob.objects.filter(
+                        user=self.request.user,
+                        job__is_removed=False
+                    ).order_by(str(order_by))
             else:
-                return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
-        return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False)
+                return SavedJob.objects.filter(
+                    user=self.request.user,
+                    job__is_removed=False
+                ).order_by(str(order_by))
+        return SavedJob.objects.filter(
+            user=self.request.user,
+            job__is_removed=False
+        )
 
 
 class UpdateJobPreferencesView(generics.GenericAPIView):

--- a/job_seekers/views.py
+++ b/job_seekers/views.py
@@ -877,12 +877,12 @@ class JobsApplyView(generics.ListAPIView):
                 order_by = 'job__deadline'
             if 'order_by' in self.request.GET:
                 if 'descending' in self.request.GET['order_by']:
-                    return AppliedJob.objects.filter(user=self.request.user).order_by("-" + str(order_by))
+                    return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by("-" + str(order_by))
                 else:
-                    return AppliedJob.objects.filter(user=self.request.user).order_by(str(order_by))
+                    return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
             else:
-                return AppliedJob.objects.filter(user=self.request.user).order_by(str(order_by))
-        return AppliedJob.objects.filter(user=self.request.user)
+                return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
+        return AppliedJob.objects.filter(user=self.request.user).filter(job__is_removed=False)
 
 
 class JobsSaveView(generics.ListAPIView):
@@ -1071,12 +1071,12 @@ class JobsSaveView(generics.ListAPIView):
                 order_by = 'job__deadline'
             if 'order_by' in self.request.GET:
                 if 'descending' in self.request.GET['order_by']:
-                    return SavedJob.objects.filter(user=self.request.user).order_by("-" + str(order_by))
+                    return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by("-" + str(order_by))
                 else:
-                    return SavedJob.objects.filter(user=self.request.user).order_by(str(order_by))
+                    return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
             else:
-                return SavedJob.objects.filter(user=self.request.user).order_by(str(order_by))
-        return SavedJob.objects.filter(user=self.request.user)
+                return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False).order_by(str(order_by))
+        return SavedJob.objects.filter(user=self.request.user).filter(job__is_removed=False)
 
 
 class UpdateJobPreferencesView(generics.GenericAPIView):

--- a/tenders/serializers.py
+++ b/tenders/serializers.py
@@ -5,6 +5,10 @@ from tenders.models import (
     TenderAttachmentsItem, TenderFilter
 )
 
+from vendors.models import (
+    SavedTender
+)
+
 from users.serializers import UserSerializer
 
 from project_meta.serializers import (
@@ -105,19 +109,19 @@ class TendersSerializers(serializers.ModelSerializer):
             user = self.context['user']
             # if user.is_authenticated:
             #     is_applied_record = AppliedJob.objects.filter(
-            #         job=obj,
+            #         tender=obj,
             #         user=user
             #     ).exists()
         return is_applied_record
 
     def get_is_saved(self, obj):
         is_saved_record = False
-        # if 'user' in self.context:
-        #     if self.context['user'].is_authenticated:
-        #         is_saved_record = SavedJob.objects.filter(
-        #             job=obj,
-        #             user=self.context['user']
-        #         ).exists()
+        if 'user' in self.context:
+            if self.context['user'].is_authenticated:
+                is_saved_record = SavedTender.objects.filter(
+                    tender=obj,
+                    user=self.context['user']
+                ).exists()
         return is_saved_record
 
     def get_vendor(self, obj):
@@ -352,7 +356,7 @@ class TendersDetailSerializers(serializers.ModelSerializer):
         return context
 
     def get_vendor(self, obj):
-        # return AppliedJob.objects.filter(job=obj).count()
+        # return AppliedJob.objects.filter(tender=obj).count()
         return 0
 
     def get_is_applied(self, obj):
@@ -360,19 +364,19 @@ class TendersDetailSerializers(serializers.ModelSerializer):
         # if 'user' in self.context:
         #     user = self.context['user']
         #     is_applied_record = AppliedJob.objects.filter(
-        #         job=obj,
+        #         tender=obj,
         #         user=user
         #     ).exists()
         return is_applied_record
 
     def get_is_saved(self, obj):
         is_saved_record = False
-        # if 'user' in self.context:
-        #     user = self.context['user']
-        #     is_saved_record = SavedJob.objects.filter(
-        #         job=obj,
-        #         user=user
-        #     ).exists()
+        if 'user' in self.context:
+            user = self.context['user']
+            is_saved_record = SavedTender.objects.filter(
+                tender=obj,
+                user=user
+            ).exists()
         return is_saved_record
 
     def get_attachments(self, obj):

--- a/vendors/urls.py
+++ b/vendors/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
 
     path('/about-me', UpdateAboutView.as_view(), name="update_about"),
     
+    path('/tender/save', TenderSaveView.as_view(), name="tender_save"),
     path('/tender/save/<str:tenderId>', TenderSaveView.as_view(), name="tender_save"),
 
 ]


### PR DESCRIPTION
# Pull Request

## Description

- change the model name in the `GetSavedJobsSerializers` serializer for the correct response.
- Reformat code in the `job_seekers/views.py` file.
- get a correct response for the `is_saved_record` parameter for tenders response data.
- create `GetSavedTenderSerializers` and `LIST function` in `TenderSaveView` for getting saved tender data.
- create a URL path for getting saved tender API.

### GetSavedTenderSerializers:
A serializer class for the SavedTender model that returns details of saved tenders.

- This serializer includes the following fields:
    - id (int): The ID of the applied tender.
    - tender (dict): A dictionary containing details of the tender posting.

The 'tender' field is a serialized representation of the related TenderDetails object, and is populated using the `get_tender` method of the GetSavedTenderSerializers class.

#### get_tender function:
A method for retrieving the details of a tender.

- `obj`: An instance of a model that has a related TenderDetails object.
- `return_context`: A dictionary that contains the serialized data of the related tender details.

The method attempts to retrieve the serialized data of the related tender details object by:
- Checking if a 'request' object is present in the context.
- Retrieving the authenticated user from the '`request`' object.
- Serializing the tender details object using the `TendersDetailSerializers` and passing the authenticated user as context.
- Checking if the serialized data is `not empty`.
- If the above steps are successful, the serialized data is returned as a dictionary.

If the `TenderDetails` object does not exist, an exception is caught and nothing is returned.

### TenderSaveView:
View for retrieving saved tenders by authenticated users.

- `serializer_class`: A serializer class for `serializing/deserializing` the saved tender data.
- `permission_classes`: A list of permission classes that define the permission policy for this view.
- `queryset`: The queryset used for retrieving the saved tenders. This is set to None as the actual queryset is generated dynamically based on the authenticated user.
- `filter_backends`: A list of filter backend classes used for filtering the saved tenders.
- `search_fields`: A list of fields on which the search filter should be applied.
- `pagination_class`: A pagination class used for pagination of the retrieved saved tenders.

#### LIST Function:
Returns a paginated list of serialized saved tenders for the authenticated user.

This method returns a paginated list of saved tenders for the authenticated user. The saved tenders are serialized using the `GetSavedTenderSerializers` class.

##### Args:
- `request`: The HTTP request object.

##### Returns:
A HTTP response object containing a paginated list of serialized saved tenders.

The response includes the following fields:
- `count (int)`: The total number of saved tenders for the authenticated user.
- `next (str)`: The URL for the next page of results, or null if there are no more pages.
- `previous (str)`: The URL for the previous page of results, or null if this is the first page.
- `results (list)`: A list of serialized saved tenders for the authenticated user.

#### get_queryset Function:
Returns the queryset of saved tenders for the authenticated user.

This method returns a queryset of SavedTender objects for the authenticated user, ordered by their creation date in descending order.

###### Args:
- `**kwargs`: Additional keyword arguments.

###### Returns:
A queryset of SavedTender objects for the authenticated user, ordered by their creation date in descending order.


Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
