### PR TITLE
#330 - activity api

### DIFF
--- a/docs/employer/employer.md
+++ b/docs/employer/employer.md
@@ -19,6 +19,7 @@ These APIs are for the `CRUD` of an `employer`
 - **[Update Tenders](#update-tenders)**
 - **[Active Inactive Job](#active-inactive-job)**
 - **[Active Inactive Tender](#active-inactive-tender)**
+- **[Dashboard Activity](#dashboard-activity)**
 
 ## Update About
 
@@ -397,6 +398,25 @@ This route is used to active inactive `tenders`
     code: 200,
     data: {
       message: "This tender placed on hold" || "This tender is active"
+    }
+  }
+  ```
+
+## Dashboard Activity
+
+This api is used to get count of `activity` for employer dashboard.
+- route: `/activity`
+- method: `GET`
+
+- response:
+  ```js
+  {
+    code: 200,
+    data: {
+        "active_jobs": 6,
+        "active_tender": 2,
+        "applied_jobs": 4,
+        "applied_tender": 0
     }
   }
   ```

--- a/employers/serializers.py
+++ b/employers/serializers.py
@@ -1,8 +1,10 @@
+from datetime import date
+
 import json
 
 from rest_framework import serializers
 
-from jobs.models import JobDetails
+from job_seekers.models import AppliedJob
 
 from project_meta.models import (
     Media, Skill, Language,
@@ -21,7 +23,8 @@ from users.models import User
 from jobs.models import (
     JobCategory,
     JobAttachmentsItem,
-    JobsLanguageProficiency
+    JobsLanguageProficiency,
+    JobDetails
 )
 
 
@@ -194,7 +197,7 @@ class CreateJobsSerializers(serializers.ModelSerializer):
             'title', 'budget_currency', 'budget_amount', 'budget_pay_period', 'description', 'country',
             'city', 'address', 'job_category', 'is_full_time', 'is_part_time', 'has_contract',
             'contact_email', 'contact_phone', 'contact_whatsapp', 'highest_education', 'language', 'skill',
-            'duration','experience', 'attachments', 'deadline', 'start_date'
+            'duration', 'experience', 'attachments', 'deadline', 'start_date'
         ]
 
     def validate_job_category(self, job_category):
@@ -587,7 +590,7 @@ class CreateTendersSerializers(serializers.ModelSerializer):
         model = TenderDetails
         fields = [
             'title', 'budget_currency', 'budget_amount', 'description', 'country', 'city',
-            'tender_category', 'tender_type', 'sector', 'tag', 'attachments', 'deadline', 
+            'tender_category', 'tender_type', 'sector', 'tag', 'attachments', 'deadline',
             'start_date'
         ]
 
@@ -734,3 +737,97 @@ class UpdateTenderSerializers(serializers.ModelSerializer):
                                                                             attachment=media_instance)
                 attachments_instance.save()
         return instance
+
+
+class ActivitySerializers(serializers.Serializer):
+    """
+    Serializer for retrieving various activity-related information for a user.
+
+    The serializer provides information on active jobs and tenders that a user has, as well as jobs and tenders that
+    the user has applied for.
+
+    Fields:
+        - `active_jobs`: The number of active jobs that the user has.
+        - `active_tender`: The number of active tenders that the user has.
+        - `applied_jobs`: The number of jobs that the user has applied for.
+        - `applied_tender`: The number of tenders that the user has applied for.
+
+    Methods:
+        - `get_active_jobs`: Returns the number of active jobs that the user has.
+        - `get_active_tender`: Returns the number of active tenders that the user has.
+        - `get_applied_jobs`: Returns the number of jobs that the user has applied for.
+        - `get_applied_tender`: Returns the number of tenders that the user has applied for.
+
+    Attributes:
+        - `model`: The Django User model that the serializer is based on.
+        - `fields`: A list of fields to be included in the serialized representation.
+
+    Usage:
+        To use this serializer, create an instance of it and pass in a User object as the argument to the `data`
+        parameter of the serializer's `__init__()` method. For example:
+
+            user = User.objects.get(pk=1)
+            serializer = ActivitySerializers(data=user)
+            serialized_data = serializer.data
+
+    """
+    active_jobs = serializers.SerializerMethodField()
+    active_tender = serializers.SerializerMethodField()
+    applied_jobs = serializers.SerializerMethodField()
+    applied_tender = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            'active_jobs', 'active_tender', 'applied_jobs', 'applied_tender'
+        ]
+
+    def get_active_jobs(self, obj):
+        """
+        Returns the number of active jobs that the user has.
+
+        Args:
+            - `obj`: The User object for which to retrieve the number of active jobs.
+
+        Returns:
+            An integer representing the number of active jobs that the user has.
+        """
+        return JobDetails.objects.filter(status='active', user=obj,
+                                         deadline__gte=date.today()).count()
+
+    def get_active_tender(self, obj):
+        """
+        Returns the number of active tenders that the user has.
+
+        Args:
+            - `obj`: The User object for which to retrieve the number of active tenders.
+
+        Returns:
+            An integer representing the number of active tenders that the user has.
+        """
+        return TenderDetails.objects.filter(status='active', user=obj,
+                                            deadline__gte=date.today()).count()
+
+    def get_applied_jobs(self, obj):
+        """
+        Returns the number of jobs that the user has applied for.
+
+        Args:
+            - `obj`: The User object for which to retrieve the number of applied jobs.
+
+        Returns:
+            An integer representing the number of jobs that the user has applied for.
+        """
+        return AppliedJob.objects.filter(job__user=obj).count()
+
+    def get_applied_tender(self, obj):
+        """
+        Returns the number of tenders that the user has applied for.
+
+        Args:
+            - `obj`: The User object for which to retrieve the number of applied tenders.
+
+        Returns:
+            An integer representing the number of tenders that the user has applied for.
+        """
+        return 0

--- a/employers/urls.py
+++ b/employers/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import (
     UpdateAboutView, JobsView,
     TendersView, JobsStatusView,
-    TendersStatusView
+    TendersStatusView, ActivityView
 )
 
 app_name = "employers"
@@ -11,6 +11,8 @@ app_name = "employers"
 urlpatterns = [
 
     path('/about-me', UpdateAboutView.as_view(), name="update_about"),
+    
+    path('/activity', ActivityView.as_view(), name="activity"),
     
     path('/jobs', JobsView.as_view(), name="jobs"), 
     path('/jobs/<str:jobId>', JobsView.as_view(), name="jobs"),


### PR DESCRIPTION
# Pull Request

## Description

- modify employer.md for Dashboard Activity.
- create URL path for employer dashboard activity API.
- create functions `ActivitySerializers` and `ActivityView` for employer dashboard API.

### ActivitySerializers:
Serializer for retrieving various activity-related information for a user.

The serializer provides information on active jobs and tenders that a user has, as well as jobs and tenders that the user has applied for.

#### Fields:
- `active_jobs`: The number of active jobs that the user has.
- `active_tender`: The number of active tenders that the user has.
- `applied_jobs`: The number of jobs that the user has applied for.
- `applied_tender`: The number of tenders that the user has applied for.

#### Methods:
- `get_active_jobs`: Returns the number of active jobs that the user has.
- `get_active_tender`: Returns the number of active tenders that the user has.
- `get_applied_jobs`: Returns the number of jobs that the user has applied for.
- `get_applied_tender`: Returns the number of tenders that the user has applied for.

#### Attributes:
- `model`: The Django User model that the serializer is based on.
- `fields`: A list of fields to be included in the serialized representation.

#### Usage:
To use this serializer, create an instance of it and pass in a User object as the argument to the `data` parameter of the serializer's `__init__()` method. For example:

    user = User.objects.get(pk=1)
    serializer = ActivitySerializers(data=user)
    serialized_data = serializer.data

#### get_active_jobs:
Returns the number of active jobs that the user has.

##### Args:
- `obj`: The User object for which to retrieve the number of active jobs.

##### Returns:
- An integer representing the number of active jobs that the user has.

#### get_active_tender:
Returns the number of active tenders that the user has.

##### Args:
- `obj`: The User object for which to retrieve the number of active tenders.

##### Returns:
- An integer representing the number of active tenders that the user has.

#### get_applied_jobs:
Returns the number of jobs that the user has applied for.

##### Args:
- `obj`: The User object for which to retrieve the number of applied jobs.

##### Returns:
- An integer representing the number of jobs that the user has applied for.

#### get_applied_tender:
Returns the number of tenders that the user has applied for.

##### Args:
- `obj`: The User object for which to retrieve the number of applied tenders.

##### Returns:
- An integer representing the number of tenders that the user has applied for.

### ActivityView:
View for retrieving various activity-related information for a user.

This view requires the user to be authenticated and returns information on active jobs and tenders that a user has, as well as jobs and tenders that the user has applied for.

#### Attributes:
- `permission_classes`: A list of permission classes that the view requires.
- `serializer_class`: The serializer class to be used for this view.

#### Methods:
- `get`: Handles GET requests and retrieves activity-related information for the user.

#### Usage:
- To use this view, make a GET request to the view's endpoint. For example:

    GET `/activity/`

The request must include a valid authentication token in the Authorization header.
If the user is an employer, the view will return activity-related information for that employer. If the user is not an employer, the view will return an error message.

#### GET Function:
Retrieves activity-related information for the user.

If the user is an employer, returns information on active jobs and tenders that the user has, as well as jobs and tenders that the user has applied for. If the user is not an employer, returns an error message.

##### Returns:
- A Response object containing the serialized activity-related information or an error message.


Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
