### PR TITLE
#247 - search user

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -11,7 +11,7 @@ from user_profile.models import (
     UserFilters, VendorProfile
 )
 
-from project_meta.models import Media
+from project_meta.models import Media, EducationLevel
 
 from project_meta.serializers import (
     CitySerializer, CountrySerializer, 
@@ -1152,3 +1152,83 @@ class GetUserFiltersSerializers(serializers.ModelSerializer):
         if get_data.data:
             context = get_data.data
         return context
+
+
+class SearchUserSerializers(serializers.ModelSerializer):
+    """
+    Serializer class for the `User` model.
+
+    The `SearchUserSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the
+    `User` model. It defines the fields that should be included in the serialized representation of the model,
+    including 'id', 'role', 'name', 'email', 'image', 'description', 'skills', 'highest_education', 'country', 'city'.
+    """
+    image = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
+    skills = serializers.SerializerMethodField()
+    highest_education = serializers.SerializerMethodField()
+    country = serializers.SerializerMethodField()
+    city = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = User
+        fields = ['id', 'role', 'name', 'email', 'image', 
+                  'description', 'skills','country', 'city', 
+                  'highest_education'
+                  ]
+
+    def get_image(self, obj):
+        context = {}
+        if obj.image:
+            context['id'] = obj.image.id
+            context['title'] = obj.image.title
+            if obj.image.title == "profile image":
+                context['path'] = str(obj.image.file_path)
+            else:
+                context['path'] = obj.image.file_path.url
+            context['type'] = obj.image.media_type
+            return context
+        return None
+    
+    def get_description(self, obj):
+        context = {}
+        if obj.role == 'job_seeker':
+            jobseeker_data = JobSeekerProfile.objects.get(user=obj)
+            return jobseeker_data.description
+        elif obj.role == 'vendor':
+            jobseeker_data = VendorProfile.objects.get(user=obj)
+            return jobseeker_data.description
+        return None    
+    
+    def get_highest_education(self, obj):
+        context = {}
+        if obj.role == 'job_seeker':
+            jobseeker_data = JobSeekerProfile.objects.get(user=obj)
+            if jobseeker_data.highest_education:
+                return jobseeker_data.highest_education.title
+        return None
+    
+    def get_country(self, obj):
+        context = {}
+        if obj.role == 'job_seeker':
+            jobseeker_data = JobSeekerProfile.objects.get(user=obj)
+            if jobseeker_data.country:
+                return jobseeker_data.country.title
+        return None
+    
+    def get_city(self, obj):
+        context = {}
+        if obj.role == 'job_seeker':
+            jobseeker_data = JobSeekerProfile.objects.get(user=obj)
+            if jobseeker_data.city:
+                return jobseeker_data.city.title
+        return None
+    
+    def get_skills(self, obj):
+        context = []
+        if obj.role == 'job_seeker':
+            skills_data = JobSeekerSkill.objects.filter(user=obj)
+            get_data = JobSeekerSkillSerializer(skills_data, many=True)
+            if get_data.data:
+                context = get_data.data
+            return context
+        return None

--- a/users/views.py
+++ b/users/views.py
@@ -33,7 +33,6 @@ from user_profile.models import (
 from notification.models import Notification
 
 from superadmin.models import GooglePlaceApi
-from superadmin.serializers import CandidatesSerializers
 
 from .models import UserSession, User
 from .filters import UsersFilter
@@ -46,7 +45,8 @@ from .serializers import (
     UpdateImageSerializers,
     SocialLoginSerializers,
     UserFiltersSerializers,
-    GetUserFiltersSerializers
+    GetUserFiltersSerializers,
+    SearchUserSerializers
 )
 
 
@@ -687,7 +687,7 @@ class SearchView(generics.ListAPIView):
     The `role` parameter is required in the URL path.
     The `limit` query parameter can be used to paginate the results.
 
-    - `Serializer class`: CandidatesSerializers
+    - `Serializer class`: SearchUserSerializers
     - `Permission classes`: AllowAny
     - `Queryset`: all User objects
     - `Filter backends`: SearchFilter
@@ -701,9 +701,9 @@ class SearchView(generics.ListAPIView):
         - /candidates/managers/?search=project+management
     """
 
-    serializer_class = CandidatesSerializers
+    serializer_class = SearchUserSerializers
     permission_classes = [permissions.AllowAny]
-    queryset = User.objects.all()
+    queryset = User.objects.filter(is_active=True)
     filter_backends = [filters.SearchFilter, django_filters.DjangoFilterBackend]
     filterset_class = UsersFilter
     search_fields = [


### PR DESCRIPTION
# Pull Request

## Description

- modify serializer_class from `CandidatesSerializers` to `SearchUserSerializers`.
- create `SearchUserSerializers` for getting user search data.

### SearchUserSerializers:
Serializer class for the `User` model.

The `SearchUserSerializers` class extends `serializers.ModelSerializer` and is used to create instances of the `User` model. It defines the fields that should be included in the serialized representation of the model, including 'id', 'role', 'name', 'email', 'image', 'description', 'skills', 'highest_education', 'country', 'city'.
    

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
