### PR TITLE
#383 - employer dashboard share count

### DIFF
--- a/employers/urls.py
+++ b/employers/urls.py
@@ -4,7 +4,8 @@ from .views import (
     UpdateAboutView, JobsView,
     TendersView, JobsStatusView,
     TendersStatusView, ActivityView,
-    JobAnalysisView, BlacklistedUserView
+    JobAnalysisView, BlacklistedUserView,
+    ShareCountView
 )
 
 app_name = "employers"
@@ -15,6 +16,7 @@ urlpatterns = [
     
     path('/activity', ActivityView.as_view(), name="activity"),
     path('/job-analysis', JobAnalysisView.as_view(), name="job_analysis"),
+    path('/share-count', ShareCountView.as_view(), name="share_count"),
     
     path('/jobs', JobsView.as_view(), name="jobs"), 
     path('/jobs/<str:jobId>', JobsView.as_view(), name="jobs"),

--- a/superadmin/serializers.py
+++ b/superadmin/serializers.py
@@ -106,8 +106,7 @@ class JobCategorySerializers(serializers.ModelSerializer):
     class Meta:
         model = JobCategory
         fields = ['id', 'title']
-        
-            
+
     def validate(self, data):
         """
         Validate the data before saving to the database.
@@ -131,7 +130,7 @@ class JobCategorySerializers(serializers.ModelSerializer):
         if JobCategory.objects.filter(title__iexact=title, is_removed=False).exists():
             raise serializers.ValidationError({'title': title + ' already exist.'})
         return data
-        
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -149,7 +148,7 @@ class EducationLevelSerializers(serializers.ModelSerializer):
     class Meta:
         model = EducationLevel
         fields = ['id', 'title']
-        
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -167,7 +166,7 @@ class LanguageSerializers(serializers.ModelSerializer):
     class Meta:
         model = Language
         fields = ['id', 'title']
-            
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -185,7 +184,7 @@ class SkillSerializers(serializers.ModelSerializer):
     class Meta:
         model = Skill
         fields = ['id', 'title']
-            
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -203,7 +202,7 @@ class TagSerializers(serializers.ModelSerializer):
     class Meta:
         model = Tag
         fields = ['id', 'title']
-                
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -523,11 +522,12 @@ class JobSeekerCategorySerializers(serializers.ModelSerializer):
                 raise serializers.ValidationError({'title': 'Sub category already exists'})
             else:
                 return data
- 
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
-        return instance   
-    
+        return instance
+
+
 class TenderCategorySerializers(serializers.ModelSerializer):
     """
     Serializer class for the `TenderCategory` model.
@@ -540,7 +540,7 @@ class TenderCategorySerializers(serializers.ModelSerializer):
     class Meta:
         model = TenderCategory
         fields = ['id', 'title']
-    
+
     def validate(self, data):
         title = data.get("title")
         if TenderCategory.objects.filter(title=title).exists():
@@ -561,7 +561,7 @@ class SectorSerializers(serializers.ModelSerializer):
     class Meta:
         model = Sector
         fields = ['id', 'title']
-        
+
     def validate(self, data):
         title = data.get("title")
         if Sector.objects.filter(title=title).exists():
@@ -579,14 +579,14 @@ class GetJobSubCategorySerializers(serializers.ModelSerializer):
     including 'id', 'title', 'category'.
     """
     category = serializers.SerializerMethodField()
+
     class Meta:
         model = JobSubCategory
         fields = ['id', 'title', 'category']
-        
+
     def get_category(self, obj):
         return {"id": obj.category.id, "title": obj.category.title}
 
-        
 
 class JobSubCategorySerializers(serializers.ModelSerializer):
     """
@@ -600,7 +600,7 @@ class JobSubCategorySerializers(serializers.ModelSerializer):
     class Meta:
         model = JobSubCategory
         fields = ['id', 'title', 'category']
-        
+
     def validate(self, data):
         """
         Validate the data before saving to the database.
@@ -628,11 +628,12 @@ class JobSubCategorySerializers(serializers.ModelSerializer):
             try:
                 if JobCategory.objects.get(title=category.title):
                     if JobSubCategory.objects.filter(title__iexact=title, category=category).exists():
-                        raise serializers.ValidationError({'title': title + ' in ' + category.title + ' already exist.'})
+                        raise serializers.ValidationError(
+                            {'title': title + ' in ' + category.title + ' already exist.'})
                     return data
             except JobCategory.DoesNotExist:
                 raise serializers.ValidationError('Job category not available.', code='category')
-        
+
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
         return instance
@@ -650,3 +651,30 @@ class AllCountrySerializers(serializers.ModelSerializer):
     class Meta:
         model = AllCountry
         fields = ['id', 'title', 'currency', 'phone_code', 'iso2', 'iso3']
+
+
+class AllCitySerializers(serializers.ModelSerializer):
+    """
+    Serializer for AllCity model that returns a serialized representation of each city, including its
+    country information. The 'country' field is a custom serializer method that returns the country information
+     as a dictionary with 'id' and 'title' keys.
+
+    Attributes:
+        - `country`: A custom `SerializerMethodField` that returns the serialized representation of the country
+                    foreign key field of AllCity model.
+
+    Meta:
+        - `model`: AllCity model for which the serializer is defined.
+        - `fields`: A list of fields to be included in the serialized representation of the AllCity model.
+                    It includes 'id', 'title', and 'country' fields.
+
+    """
+
+    country = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AllCountry
+        fields = ['id', 'title', 'country']
+
+    def get_country(self, obj):
+        return {"id": obj.country.id, "title": obj.country.title}

--- a/superadmin/urls.py
+++ b/superadmin/urls.py
@@ -8,7 +8,8 @@ from .views import (
     JobsListView, UsersCountView, UserView,
     JobsRevertView, DashboardView, JobSeekerCategoryView,
     TenderCategoryView, SectorView, UploadCountryView,
-    JobSubCategoryView, WorldCountryView, UploadCityView
+    JobSubCategoryView, WorldCountryView, UploadCityView,
+    WorldCityView
 )
 
 app_name = "superadmin"
@@ -72,4 +73,5 @@ urlpatterns = [
     path('/job-sub-category/<str:jobSubCategoryId>', JobSubCategoryView.as_view(), name="job_sub_category"),
     
     path('/world-country', WorldCountryView.as_view(), name="world_country"),
+    path('/world-city', WorldCityView.as_view(), name="world_city"),
 ]


### PR DESCRIPTION
# Pull Request

## Description

- create `ShareCountSerializers` and `ShareCountView` for getting all jobs to share the count of logged-in employers.
- create a URL path for getting all jobs share count of logged-in employers.

### ShareCountSerializers:
A Django REST Framework serializer for computing share counts for a user's jobs.

This serializer computes the number of shares for a user's jobs on various platforms, including `WhatsApp`, `Telegram`, `Facebook`, `LinkedIn`, `email`, and `direct link`. It also computes the `total number` of shares across all platforms.

#### Attributes:
- `whatsapp (serializers.SerializerMethodField)`: A method field for computing the number of `WhatsApp` shares.
- `telegram (serializers.SerializerMethodField)`: A method field for computing the number of `Telegram` shares.
- `facebook (serializers.SerializerMethodField)`: A method field for computing the number of `Facebook` shares.
- `linked_in (serializers.SerializerMethodField)`: A method field for computing the number of `LinkedIn` shares.
- `mail (serializers.SerializerMethodField)`: A method field for computing the number of `email` shares.
- `direct_link (serializers.SerializerMethodField)`: A method field for computing the number of `direct link` shares.
- `total (serializers.SerializerMethodField)`: A method field for computing the `total number` of shares across all platforms.

### ShareCountView:
The ShareCountView is a class-based view that returns the number of shares made by the authenticated user.

#### Attributes:
- `permission_classes (list)`: A list of permission classes that must be satisfied in order for the view to be accessed. In this case, only authenticated users can access the view.
- `serializer_class (class)`: The serializer class that will be used to serialize and deserialize the data returned by the view.

#### Methods:
- `get(self, request)`: Returns the number of shares made by the authenticated user. If the user is an employer, the view will attempt to serialize the user data using the serializer class specified in the serializer_class attribute and return the serialized data in the response. If the serialization fails, a 400 bad request response will be returned with an error message. If the user is not an employer, a 401 unauthorized response will be returned with a message indicating that the user does not have permission to perform the action.

#### Usage:
Instantiate ShareCountView in urls.py to map the view to a URL and provide the required authentication credentials for the user.


Please delete the options that are not relevant.

[x] New feature (unwavering change that adds features)
[x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
[ ] This change requires a documentation update
