### PR TITLE
#502 - employer verification api

### DIFF
--- a/employers/views.py
+++ b/employers/views.py
@@ -143,7 +143,7 @@ class JobsView(generics.ListAPIView):
         context = dict()
         serializer = CreateJobsSerializers(data=request.data)
         try:
-            if self.request.user.role == "employer":
+            if self.request.user.role == "employer" and self.request.user.user_profile_employerprofile_user.first().is_verified:
                 serializer.is_valid(raise_exception=True)
                 serializer.save(self.request.user)
                 context["message"] = "Job added successfully."
@@ -441,7 +441,7 @@ class TendersView(generics.ListAPIView):
         context = dict()
         serializer = CreateTendersSerializers(data=request.data)
         try:
-            if self.request.user.role == "employer":
+            if self.request.user.role == "employer" and self.request.user.user_profile_employerprofile_user.first().is_verified:
                 serializer.is_valid(raise_exception=True)
                 serializer.save(self.request.user)
                 context["message"] = "Tender added successfully."

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -578,6 +578,7 @@ class EmployerProfileSerializer(serializers.ModelSerializer):
             'website',
             'country',
             'city',
+            'is_verified'
         )
 
     def get_license_id_file(self, obj):


### PR DESCRIPTION
# Pull Request

## Description

- send the `is_verified` value in the employer profile to get user detail API.
- set validation for create `jobs` and `tenders` for `(employer verified or not)`.

Please delete the options that are not relevant.

- [x] New feature (unwavering change that adds features)
- [x] Resounding change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
